### PR TITLE
WINDUP-1986 Fix to download artifacts

### DIFF
--- a/src/it/simple-it/pom.xml
+++ b/src/it/simple-it/pom.xml
@@ -22,7 +22,7 @@
       <plugin>
         <groupId>org.jboss.windup.plugin</groupId>
         <artifactId>windup-maven-plugin</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.2.0.Final</version>
         <executions>
           <execution>
             <id>run-windup</id>

--- a/src/main/java/org/jboss/windup/plugin/WindupMojo.java
+++ b/src/main/java/org/jboss/windup/plugin/WindupMojo.java
@@ -34,6 +34,7 @@ import org.apache.maven.settings.Settings;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
@@ -81,6 +82,8 @@ public class WindupMojo extends AbstractMojo
 {
     private static final String VERSION_DEFINITIONS_FILE = "META-INF/versions.properties";
 
+    @Parameter(defaultValue = "${project.remotePluginRepositories}", readonly = true)
+    private List<RemoteRepository> remoteRepos;
 
     @Parameter(defaultValue = "${project.build.directory}")
     private String buildDirectory;
@@ -356,6 +359,7 @@ public class WindupMojo extends AbstractMojo
         {
             windupRulesetsVersion = windupVersion;
         }
+        artifactRequest.setRepositories(remoteRepos);
         artifactRequest.setArtifact(new DefaultArtifact(WINDUP_RULES_GROUP_ID + ":" + WINDUP_RULES_ARTIFACT_ID + ":" + windupRulesetsVersion));
         try
         {

--- a/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
+++ b/src/test/java/org/jboss/windup/plugin/WindupMojoTest.java
@@ -1,8 +1,14 @@
 package org.jboss.windup.plugin;
 
 
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequestPopulator;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,8 +40,6 @@ public class WindupMojoTest extends AbstractMojoTestCase
         }
     }
 
-
-
     public void testNoWindupVersionParameter() throws Exception
     {
         File testPom = new File( getBasedir(),
@@ -57,12 +61,21 @@ public class WindupMojoTest extends AbstractMojoTestCase
                 "src/test/resources/mojoTestConfigWithWindupVersion.xml" );
         assertNotNull(testPom);
 
-        WindupMojo mojo2 = (WindupMojo)lookupMojo("windup", testPom);
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        MavenExecutionRequestPopulator populator = getContainer().lookup( MavenExecutionRequestPopulator.class );
+        populator.populateDefaults(executionRequest);
+        executionRequest.setSystemProperties(System.getProperties());
+
+        ProjectBuildingRequest buildingRequest = executionRequest.getProjectBuildingRequest();
+        ProjectBuilder projectBuilder = this.lookup(ProjectBuilder.class);
+        MavenProject project = projectBuilder.build(testPom, buildingRequest).getProject();
+
+        WindupMojo mojo2 = (WindupMojo)lookupConfiguredMojo(project, "windup");
         assertNotNull( mojo2 );
         assertNotNull(mojo2.getWindupVersion());
         mojo2.execute();
 
 
-        assertEquals(mojo2.getWindupVersion(), "4.1.0-SNAPSHOT");
+        assertEquals(mojo2.getWindupVersion(), "4.2.0.Final");
     }
 }

--- a/src/test/resources/mojoTestConfig.xml
+++ b/src/test/resources/mojoTestConfig.xml
@@ -4,7 +4,7 @@
             <plugin>
                 <groupId>org.jboss.windup.plugin</groupId>
                 <artifactId>windup-maven-plugin</artifactId>
-                <version>4.1.0-SNAPSHOT</version>
+                <version>4.2.0.Final</version>
                 <executions>
                     <execution>
                         <id>run-windup</id>

--- a/src/test/resources/mojoTestConfigWithWindupVersion.xml
+++ b/src/test/resources/mojoTestConfigWithWindupVersion.xml
@@ -1,10 +1,18 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.windup.plugin.it</groupId>
+    <artifactId>simple-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.jboss.windup.plugin</groupId>
                 <artifactId>windup-maven-plugin</artifactId>
-                <version>4.1.0-SNAPSHOT</version>
+                <version>4.1.0.Final</version>
                 <executions>
                     <execution>
                         <id>run-windup</id>
@@ -25,7 +33,7 @@
                     <outputDirectory>target</outputDirectory>
                     <offlineMode>true</offlineMode>
                     <overwrite>false</overwrite>
-                    <windupVersion>4.1.0-SNAPSHOT</windupVersion>
+                    <windupVersion>4.2.0.Final</windupVersion>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This changes should fix the issue about downloading artifacts with the exception

_java.lang.RuntimeException: org.eclipse.aether.resolution.ArtifactResolutionException: Could not find artifact org.jboss.windup.rules:windup-rulesets:jar:4.1.0-SNAPSHOT
	at org.jboss.windup.plugin.WindupMojoTest.testWindupVersionParameterPresent(WindupMojoTest.java:63)_